### PR TITLE
Make the cpp path non-absolute.

### DIFF
--- a/src/nfuzz.ml
+++ b/src/nfuzz.ml
@@ -53,7 +53,7 @@ let parseArgs () =
 let parse file =
   let readme,writeme = Unix.pipe () in
   ignore (Unix.create_process
-      "/usr/bin/cpp" [|"/usr/bin/cpp" ; "-w" ; file |]
+      "cpp" [|"cpp" ; "-w" ; file |]
       Unix.stdin writeme Unix.stderr);
   Unix.close writeme;
   let pi = Unix.in_channel_of_descr readme in


### PR DESCRIPTION
Not all systems have the C preprocessor at /usr/bin/cpp. It seems that Unix.create_process searches PATH, so simply providing "cpp" will work.