### PR TITLE
Add dummy lifting/lowering operations between NumFuzz (with sub) and core

### DIFF
--- a/src/nfuzz.ml
+++ b/src/nfuzz.ml
@@ -138,6 +138,7 @@ let relative_error1 ty =
 let relative_error2 si =
   match si with SiConst f -> Some (f /. (1.0 -. f)) | _ -> None
 
+
 let type_check program =
   let ty = Ty_bi.get_type program in
   main_info dp "Type of the program: @[%a@]" Print.pp_type ty;
@@ -185,7 +186,8 @@ let main () =
   (* Print the results of the parsing phase *)
   main_debug dp "Parsed program:@\n@[%a@]@." Print.pp_term program;
 
-  (* if comp_enabled TypeChecker then type_check program; *)
+  let paired_program = Paired.lower_term_to_core program in
+  if comp_enabled TypeChecker then type_check paired_program;
 
   (if comp_enabled Backend then
      match !outfile with

--- a/src/paired.ml
+++ b/src/paired.ml
@@ -1,0 +1,76 @@
+open Syntax
+open Support.Error
+open Support.Options
+
+(* Assume that we do not have subtraction. 
+   If we encounter a subtraction operation, fail loudly. 
+   Otherwise, term_core contains the same information as term.*)
+let lower_op_to_core (op: op) finfo : op_core =
+  match op with
+  | AddOp -> AddOpCore
+  | SubOp -> 
+      error_msg General finfo "Subtraction is not supported as a core operation."
+  | MulOp -> MulOpCore
+  | SqrtOp -> SqrtOpCore
+  | DivOp -> DivOpCore
+  | GtOp -> GtOpCore
+  | EqOp -> EqOpCore
+
+(* Lower a program of type term to core, assuming that 
+   subtraction is not used. *)
+let rec lower_term_to_core (program: term) : term_core =
+  match program with
+  | TmPrim (finfo, x) -> TmPrimCore (finfo, x)
+  | TmVar (finfo, x) -> TmVarCore (finfo, x)
+  | TmLet (finfo, b, c, tm1, tm2) -> TmLetCore (finfo, b, c, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmAbs (finfo, b, c, tm) -> TmAbsCore (finfo, b, c, lower_term_to_core tm)
+  | TmRnd16 (finfo, tm) -> TmRnd16Core (finfo, lower_term_to_core tm)
+  | TmRnd32 (finfo, tm) -> TmRnd32Core (finfo, lower_term_to_core tm)
+  | TmRnd64 (finfo, tm) -> TmRnd64Core (finfo, lower_term_to_core tm)
+  | TmRet (finfo, tm) -> TmRetCore (finfo, lower_term_to_core tm)
+  | TmOp (finfo, op, tm) -> TmOpCore (finfo, lower_op_to_core op finfo, lower_term_to_core tm) (* handle this later *)
+  | TmBox (finfo, b, tm) -> TmBoxCore (finfo, b, lower_term_to_core tm)
+  | TmAmp1 (finfo, tm) -> TmAmp1Core (finfo, lower_term_to_core tm) 
+  | TmAmp2 (finfo, tm) -> TmAmp2Core (finfo, lower_term_to_core tm)
+  | TmInr (finfo, tm) -> TmInrCore (finfo, lower_term_to_core tm)
+  | TmInl (finfo, tm) -> TmInlCore (finfo, lower_term_to_core tm)
+  | TmApp (finfo, tm1, tm2) -> TmAppCore (finfo, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmTens (finfo, tm1, tm2) -> TmTensCore (finfo, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmLetBind (finfo, b, tm1, tm2) -> TmLetBindCore (finfo, b, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmTensDest (finfo, b, c, tm1, tm2) -> TmTensDestCore (finfo, b, c, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmAmpersand (finfo, tm1, tm2) -> TmAmpersandCore (finfo, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmBoxDest (finfo, b, tm1, tm2) -> TmBoxDestCore (finfo, b, lower_term_to_core tm1, lower_term_to_core tm2)
+  | TmUnionCase (finfo, tm1, c, tm2, e, tm3) -> TmUnionCaseCore (finfo, lower_term_to_core tm1, c, lower_term_to_core tm2, e, lower_term_to_core tm3)
+
+let lift_core_op_to_op (op: op_core) : op =
+  match op with
+  | AddOpCore -> AddOp
+  | MulOpCore -> MulOp
+  | SqrtOpCore -> SqrtOp
+  | DivOpCore -> DivOp
+  | GtOpCore -> GtOp
+  | EqOpCore -> EqOp
+
+let rec lift_core_to_term (core_program : term_core) : term = 
+  match core_program with
+  | TmPrimCore (finfo, x) -> TmPrim (finfo, x)
+  | TmVarCore (finfo, x) -> TmVar (finfo, x)
+  | TmLetCore (finfo, b, c, tm1, tm2) -> TmLet (finfo, b, c, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmAbsCore (finfo, b, c, tm) -> TmAbs (finfo, b, c, lift_core_to_term tm)
+  | TmRnd16Core (finfo, tm) -> TmRnd16 (finfo, lift_core_to_term tm)
+  | TmRnd32Core (finfo, tm) -> TmRnd32 (finfo, lift_core_to_term tm)
+  | TmRnd64Core (finfo, tm) -> TmRnd64 (finfo, lift_core_to_term tm)
+  | TmRetCore (finfo, tm) -> TmRet (finfo, lift_core_to_term tm)
+  | TmOpCore (finfo, op, tm) -> TmOp (finfo, lift_core_op_to_op op, lift_core_to_term tm) (* handle this later *)
+  | TmBoxCore (finfo, b, tm) -> TmBox (finfo, b, lift_core_to_term tm)
+  | TmAmp1Core (finfo, tm) -> TmAmp1 (finfo, lift_core_to_term tm) 
+  | TmAmp2Core (finfo, tm) -> TmAmp2 (finfo, lift_core_to_term tm)
+  | TmInrCore (finfo, tm) -> TmInr (finfo, lift_core_to_term tm)
+  | TmInlCore (finfo, tm) -> TmInl (finfo, lift_core_to_term tm)
+  | TmAppCore (finfo, tm1, tm2) -> TmApp (finfo, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmTensCore (finfo, tm1, tm2) -> TmTens (finfo, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmLetBindCore (finfo, b, tm1, tm2) -> TmLetBind (finfo, b, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmTensDestCore (finfo, b, c, tm1, tm2) -> TmTensDest (finfo, b, c, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmAmpersandCore (finfo, tm1, tm2) -> TmAmpersand (finfo, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmBoxDestCore (finfo, b, tm1, tm2) -> TmBoxDest (finfo, b, lift_core_to_term tm1, lift_core_to_term tm2)
+  | TmUnionCaseCore (finfo, tm1, c, tm2, e, tm3) -> TmUnionCase (finfo, lift_core_to_term tm1, c, lift_core_to_term tm2, e, lift_core_to_term tm3)

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -216,36 +216,36 @@ type term =
 type term_core =
   | TmVarCore of info * var_info
   (*  *)
-  | TmTensCore of info * term * term
-  | TmTensDestCore of info * binder_info * binder_info * term * term
-  | TmInlCore of info * term
-  | TmInrCore of info * term
-  | TmUnionCaseCore of info * term * binder_info * term * binder_info * term
+  | TmTensCore of info * term_core * term_core
+  | TmTensDestCore of info * binder_info * binder_info * term_core * term_core
+  | TmInlCore of info * term_core
+  | TmInrCore of info * term_core
+  | TmUnionCaseCore of info * term_core * binder_info * term_core * binder_info * term_core
   (*                      t  of { inl(x)     => tm1  | inl(y)     => tm2  } *)
-  (* Primitive terms *)
+  (* Primitive core terms *)
   | TmPrimCore of info * term_prim
   (* Rounding *)
-  | TmRnd64Core of info * term
-  | TmRnd32Core of info * term
-  | TmRnd16Core of info * term
+  | TmRnd64Core of info * term_core
+  | TmRnd32Core of info * term_core
+  | TmRnd16Core of info * term_core
   (* Ret *)
-  | TmRetCore of info * term
+  | TmRetCore of info * term_core
   (* Regular Abstraction and Applicacion *)
-  | TmAppCore of info * term * term
-  | TmAbsCore of info * binder_info * ty * term
+  | TmAppCore of info * term_core * term_core
+  | TmAbsCore of info * binder_info * ty * term_core
   (* & constructor and eliminator *)
-  | TmAmpersandCore of info * term * term
-  | TmAmp1Core of info * term
-  | TmAmp2Core of info * term
+  | TmAmpersandCore of info * term_core * term_core
+  | TmAmp1Core of info * term_core
+  | TmAmp2Core of info * term_core
   (* Box constructor and elim *)
-  | TmBoxCore of info * si * term
-  | TmBoxDestCore of info * binder_info * term * term
+  | TmBoxCore of info * si * term_core
+  | TmBoxDestCore of info * binder_info * term_core * term_core
   (* Regular sequencing *)
-  | TmLetCore of info * binder_info * ty option * term * term
+  | TmLetCore of info * binder_info * ty option * term_core * term_core
   (* Monadic sequencing *)
-  | TmLetBindCore of info * binder_info * term * term
+  | TmLetBindCore of info * binder_info * term_core * term_core
   (* Basic ops *)
-  | TmOpCore of info * op_core * term
+  | TmOpCore of info * op_core * term_core
 
 let map_prim_ty n f p =
   match p with


### PR DESCRIPTION
Commit 131452944890fbfa98dfcbf39ee08f8f78f769d1 turned off type checking (I didn't realize I had an open PR #6 based off my main branch and the commit accidentally snuck into the main repo). 

I'm still working on implementing the proper lowering operation to translate NumFuzz (with subtraction) into a paired NumFuzz. In the meantime, this PR is a cherry-picked version of 55a96f085b8643fc73dbbf25eddec3aa2aa97cd9 that adds a dummy lowering operation that will fail loudly if it encounters a NumFuzz program with subtraction.