### PR TITLE
Remove Unmatched Parentheses in Benchmarks

### DIFF
--- a/examples/NumFuzz/hypot.fz
+++ b/examples/NumFuzz/hypot.fz
@@ -10,7 +10,7 @@ function hypot
   let x2 = s1;
   s2 = mulfp64(y,y);
   let y2 = s2;
-  s3 = addfp64<x2,y2|);
+  s3 = addfp64<x2,y2>;
   let y3 = s3;
   sqrtfp64 [y3{0.5}]
 }

--- a/examples/NumFuzz/predatorPrey.fz
+++ b/examples/NumFuzz/predatorPrey.fz
@@ -11,7 +11,7 @@ function predatorPrey
  let s2 = s1;
  s3 = mulfp64 (s2, s2);
  let s4 = s3;
- s4 = addfp64 <1.0,s4|);
+ s4 = addfp64 <1.0,s4>;
  let s5 = s4;
  s6 = mulfp64 (4.0,x);
  let s7 = s6;


### PR DESCRIPTION
The benchmarks `hypot.fz` and `predatorPrey.fz` had unmatched parentheses from the original Cartesian pair constructor, causing parsing to fail on these tests. 